### PR TITLE
Use latest tag for devel image

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Web UI for testing ansible templates
 ### Pull
 
 ```
-docker pull sivel/ansible-template-ui:devel
+docker pull sivel/ansible-template-ui:latest
 ```
 
 ### Build
 
 ```
-docker build -t ansible-template-ui:devel docker/devel
+docker build -t ansible-template-ui:latest docker/devel
 ```
 
 ## Web App


### PR DESCRIPTION
There're only `latest` and `stable` tags published to docker hub https://hub.docker.com/r/sivel/ansible-template-ui/tags.

And `devel` in UI corresponds to the `latest` tag.

https://github.com/sivel/ansible-template-ui/blob/043b56072a8f51a24413380b482c18d9016716bd/ansible_template_ui/client/index.html#L72-L75

https://github.com/sivel/ansible-template-ui/blob/043b56072a8f51a24413380b482c18d9016716bd/ansible_template_ui/client/app.js#L26

Hope this change makes it easier for newcomers to get started.